### PR TITLE
update: IPv4 octets only allow 0-255

### DIFF
--- a/src/common/regex-patterns.ts
+++ b/src/common/regex-patterns.ts
@@ -16,8 +16,8 @@ export const US_PHONE_NATIONAL_PATTERN = /^\d{10}$/;
 export const US_PHONE_11_DIGIT_PATTERN = /^1\d{10}$/;
 export const US_PHONE_DIGITS_ONLY_PATTERN = /\D/g; // For removing non-digits
 
-// URL validation
-export const IPV4_PATTERN = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+// IPv4 validation
+export const IPV4_PATTERN = /^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$/;
 
 // Postal code validation (US ZIP codes)
 export const US_ZIP_CODE_PATTERN = /^[\d]{5}(-\d{4})?$/;

--- a/tests/regex-patterns.test.ts
+++ b/tests/regex-patterns.test.ts
@@ -244,13 +244,14 @@ describe('Regex Patterns', () => {
 
     it('should not match invalid IPv4 addresses', () => {
       const invalidIPv4 = [
-        // Note: Current pattern allows 256.256.256.256 (basic format check only)
-        '192.168.1', // incomplete
+        '192.168.1', // too few octets
         '192.168.1.1.1', // too many octets
-        'localhost',
-        'not.an.ip.address',
-        '',
-        '1234.5678.90.12', // clearly invalid format
+        'localhost', // incorrect number format
+        'not.an.ip.address', // incorrect number format
+        '', // incorrect number format
+        '1234.5678.90.12', // more than 3 numbers in octets
+        '-120.-140.-150.-160', // octets should not contain negative nubmers
+        '(1.1.1.1)', // octets should not contain symbols
       ];
 
       invalidIPv4.forEach(ip => {
@@ -258,15 +259,18 @@ describe('Regex Patterns', () => {
       });
     });
 
-    it('should match IPv4-like patterns (note: does not validate ranges)', () => {
-      // The current pattern is a basic format check, not a strict IPv4 validator
-      const basicIPv4Format = [
-        '256.256.256.256', // technically invalid but matches pattern
-        '999.999.999.999', // technically invalid but matches pattern
+    it('should not match octets above 255', () => {
+      const aboveMaximumIPv4Format = [
+        '256.256.256.256', // above maximum range 255.255.255.255
+        '999.999.999.999', // above maximum range 255.255.255.255
+        '256.255.255.255', // first octet above maximum range 255
+        '255.256.255.255', // second octet above maximum range 255
+        '255.255.256.255', // third octet above maximum range 255
+        '255.255.255.256', // fourth octet above maximum range 255
       ];
 
-      basicIPv4Format.forEach(ip => {
-        expect(IPV4_PATTERN.test(ip)).toBe(true);
+      aboveMaximumIPv4Format.forEach(ip => {
+        expect(IPV4_PATTERN.test(ip)).toBe(false);
       });
     });
   });

--- a/tests/string-utils.test.ts
+++ b/tests/string-utils.test.ts
@@ -1,4 +1,4 @@
-import { trimOrUndefined, trimOrEmpty } from '../src/utils/string-utils';
+import { trimOrUndefined, trimOrEmpty } from '../src/common/utils/string-utils';
 import { runTableTests } from './setup';
 
 describe('Utility Functions', () => {


### PR DESCRIPTION
Improved IPv4 validation to restrict octets to the valid range (0–255)
This update enhances the string validator to ensure each IPv4 octet strictly falls within the valid range of 0 to 255, preventing invalid addresses from being accepted.