### PR TITLE
chore: release v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantom-zod",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "type": "module",
   "description": "TypeScript-first schema validation library built on Zod",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v1.3.0 with new top-level exports for enum, address, and postal code schemas