### PR TITLE
feat: add string parameter overloads for NumberOptional and NumberRequired (v1.6.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantom-zod",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "type": "module",
   "description": "TypeScript-first schema validation library built on Zod",
   "main": "dist/index.js",

--- a/src/schemas/number-schemas.ts
+++ b/src/schemas/number-schemas.ts
@@ -645,9 +645,40 @@ function createSafeIntegerOptionalOverload(
   return defaultNumberSchemas.SafeIntegerOptional(msgOrOptions);
 }
 
+// Create overloads for NumberOptional and NumberRequired
+function createNumberOptionalOverload(
+  msg: string,
+): ReturnType<typeof defaultNumberSchemas.NumberOptional>;
+function createNumberOptionalOverload(
+  options?: NumberSchemaOptions,
+): ReturnType<typeof defaultNumberSchemas.NumberOptional>;
+function createNumberOptionalOverload(
+  msgOrOptions?: string | NumberSchemaOptions,
+): ReturnType<typeof defaultNumberSchemas.NumberOptional> {
+  if (typeof msgOrOptions === "string") {
+    return defaultNumberSchemas.NumberOptional({ msg: msgOrOptions });
+  }
+  return defaultNumberSchemas.NumberOptional(msgOrOptions);
+}
+
+function createNumberRequiredOverload(
+  msg: string,
+): ReturnType<typeof defaultNumberSchemas.NumberRequired>;
+function createNumberRequiredOverload(
+  options?: NumberSchemaOptions,
+): ReturnType<typeof defaultNumberSchemas.NumberRequired>;
+function createNumberRequiredOverload(
+  msgOrOptions?: string | NumberSchemaOptions,
+): ReturnType<typeof defaultNumberSchemas.NumberRequired> {
+  if (typeof msgOrOptions === "string") {
+    return defaultNumberSchemas.NumberRequired({ msg: msgOrOptions });
+  }
+  return defaultNumberSchemas.NumberRequired(msgOrOptions);
+}
+
 // Export schemas with string parameter overloads
-export const NumberOptional = defaultNumberSchemas.NumberOptional;
-export const NumberRequired = defaultNumberSchemas.NumberRequired;
+export const NumberOptional = createNumberOptionalOverload;
+export const NumberRequired = createNumberRequiredOverload;
 export const NumberStringOptional = defaultNumberSchemas.NumberStringOptional;
 export const NumberStringRequired = defaultNumberSchemas.NumberStringRequired;
 export const IntegerRequired = createIntegerRequiredOverload;

--- a/tests/number-schemas.test.ts
+++ b/tests/number-schemas.test.ts
@@ -390,7 +390,82 @@ describe("Number Schemas", () => {
     });
   });
 
-  // Tests for specialized number schema string parameter overloads
+  // Tests for basic and specialized number schema string parameter overloads
+  describe("Number Schema String Parameter Overloads", () => {
+    describe("NumberOptional overloads", () => {
+      it("should work with string parameter (new simple syntax)", () => {
+        const schema = NumberOptional('Score');
+        
+        // Should work with valid values
+        expect(schema.parse(123)).toBe(123);
+        expect(schema.parse(123.45)).toBe(123.45);
+        expect(schema.parse('456')).toBe(456);
+        expect(schema.parse(undefined)).toBeUndefined();
+        
+        // Should use the string as field name in error messages
+        expect(() => schema.parse('invalid')).toThrow('Score must be a number');
+      });
+
+      it("should still work with options object (backward compatibility)", () => {
+        const schema = NumberOptional({ msg: 'Player Score', min: 0, max: 100 });
+        
+        expect(schema.parse(50)).toBe(50);
+        expect(schema.parse(undefined)).toBeUndefined();
+        expect(() => schema.parse(150)).toThrow('Player Score');
+      });
+
+      it("should work with no parameters (default usage)", () => {
+        const schema = NumberOptional();
+        
+        expect(schema.parse(123)).toBe(123);
+        expect(schema.parse(undefined)).toBeUndefined();
+        expect(() => schema.parse('invalid')).toThrow('Value must be a number');
+      });
+
+      it("should work with constraints via options object", () => {
+        const schema = NumberOptional({ msg: 'Limit', min: 1, max: 100 }).default(50);
+        
+        expect(schema.parse(25)).toBe(25);
+        expect(schema.parse(undefined)).toBe(50);
+        expect(() => schema.parse(150)).toThrow('Limit must be at most 100');
+      });
+    });
+
+    describe("NumberRequired overloads", () => {
+      it("should work with string parameter (new simple syntax)", () => {
+        const schema = NumberRequired('Score');
+        
+        // Should work with valid values
+        expect(schema.parse(123)).toBe(123);
+        expect(schema.parse(123.45)).toBe(123.45);
+        expect(schema.parse('456')).toBe(456);
+        
+        // Should use the string as field name in error messages
+        expect(() => schema.parse('invalid')).toThrow('Score must be a number');
+      });
+
+      it("should still work with options object (backward compatibility)", () => {
+        const schema = NumberRequired({ msg: 'Player Score', min: 0, max: 100 });
+        
+        expect(schema.parse(50)).toBe(50);
+        expect(() => schema.parse(150)).toThrow('Player Score');
+      });
+
+      it("should work with no parameters (default usage)", () => {
+        const schema = NumberRequired();
+        
+        expect(schema.parse(123)).toBe(123);
+        expect(() => schema.parse('invalid')).toThrow('Value must be a number');
+      });
+
+      it("should work with constraints via options object", () => {
+        const schema = NumberRequired({ msg: 'Limit', min: 1, max: 100 });
+        
+        expect(schema.parse(25)).toBe(25);
+        expect(() => schema.parse(150)).toThrow('Limit must be at most 100');
+      });
+    });
+
   describe("Specialized Number Schema String Parameter Overloads", () => {
     describe("IntegerRequired overloads", () => {
       it("should work with string parameter (new simple syntax)", () => {
@@ -614,6 +689,7 @@ describe("Number Schemas", () => {
         expect(positiveSchema2.parse(100)).toBe(100);
       });
     });
+  });
   });
 });
 


### PR DESCRIPTION
Add string parameter overloads for basic number schemas to provide API consistency.

NEW FEATURES:
- NumberOptional and NumberRequired now support string parameter syntax
- Enables pz.NumberOptional('Limit') and pz.NumberRequired('Score')
- Maintains full backward compatibility with options object syntax

TECHNICAL CHANGES:
- Added createNumberOptionalOverload and createNumberRequiredOverload functions
- Export overloaded functions instead of direct schema functions  
- Full TypeScript support with proper overload signatures

TESTING:
- All 1300+ tests passing
- New comprehensive tests for string parameter syntax
- Backward compatibility tests maintained

BENEFITS:
- API consistency across all number schema types
- Improved developer experience for simple use cases
- Zero breaking changes to existing code

Version bumped from 1.6.1 to 1.6.2 (patch release)