### PR TITLE
fix: Remove unused string utility imports

### DIFF
--- a/src/schemas/string-schemas.ts
+++ b/src/schemas/string-schemas.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 
 import type { ErrorMessageFormatter } from "../localization/types/message-handler.types";
 import { createTestMessageHandler } from "../localization/types/message-handler.types";
-import { trimOrEmpty, trimOrUndefined } from "../common/utils/string-utils";
 import { MsgType } from "../common/types/msg-type";
 import type { StringSchemaOptions } from "../common/types/schema-options.types";
 


### PR DESCRIPTION
- Removes unused trimOrEmpty and trimOrUndefined imports
- Fixes linter warnings about unused variables  
- Keeps functionality intact

This is a minor cleanup to address linter warnings that appeared after recent string schema refactoring.